### PR TITLE
Enable token loading from .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The script determines your location automatically and caches results to avoid un
 
 - Python 3.10+
 - An OpenWeatherMap API token provided via the `OWM_TOKEN` environment variable
+  or a `.env` file containing a line like `TOKEN=your-token`
 - `click` (installable with `pip`)
 
 ## Installation
@@ -66,6 +67,8 @@ Responses are stored as JSON in `~/.cache/weather.json` (or `$STORAGE/.cache/wea
 
 ```bash
 OWM_TOKEN=your-token python -m weather.cli -c "Denver" --units imperial
+# or set TOKEN in a .env file and simply run:
+python -m weather.cli -c "Denver" --units imperial
 ```
 
 A single line of JSON describing the current weather will be printed to `stdout`.

--- a/weather/cli.py
+++ b/weather/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+from pathlib import Path
 
 import click
 
@@ -67,7 +68,15 @@ def main(
 
     token = os.environ.get("OWM_TOKEN")
     if not token:
-        raise click.ClickException("OWM_TOKEN environment variable not set")
+        env_path = Path(__file__).resolve().parent.parent / ".env"
+        if env_path.is_file():
+            for line in env_path.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if line.startswith("TOKEN="):
+                    token = line.split("=", 1)[1].strip()
+                    break
+    if not token:
+        raise click.ClickException("No OpenWeatherMap token found in OWM_TOKEN or .env")
 
     try:
         lat, lon = resolve_location(lat, lon, city, token)


### PR DESCRIPTION
## Summary
- read OpenWeatherMap token from `OWM_TOKEN` or `.env`
- document `.env` usage

## Testing
- `black -q .`


------
https://chatgpt.com/codex/tasks/task_e_688c59f3e438832588aaac5385116025