### PR TITLE
Fix termux location fallback

### DIFF
--- a/weather/core/location.py
+++ b/weather/core/location.py
@@ -73,19 +73,22 @@ def _location_from_config() -> Optional[Tuple[float, float]]:
 def _location_from_termux() -> Tuple[float, float]:
     """Retrieve GPS coordinates using ``termux-location``.
 
-    A `WeatherError` is raised when the command fails or returns
-    malformed data. Successful calls return a tuple of latitude and
-    longitude.
+    A `WeatherError` is raised when the command fails, the binary is
+    missing, or the data is malformed. Successful calls return a tuple
+    of latitude and longitude.
     """
-    result = subprocess.run(
-        [
-            "termux-location",
-            "-p",
-            "gps",
-        ],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            [
+                "termux-location",
+                "-p",
+                "gps",
+            ],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise WeatherError("Failed to obtain location from termux") from exc
     if result.returncode != 0 or not result.stdout:
         raise WeatherError("Failed to obtain location from termux")
     try:


### PR DESCRIPTION
## Summary
- handle FileNotFoundError when termux-location is missing

## Testing
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_688c6667681c8325a7b241baab671ee3