### PR TITLE
Implement hatch build backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,20 @@ The script determines your location automatically and caches results to avoid un
 
 ## Installation
 
-Clone the repository and install the package in editable mode:
+Clone the repository and install the package using
+[Hatch](https://hatch.pypa.io/):
 
 ```bash
-pip install --user -e .
+pip install --upgrade hatch
+hatch build
+pip install dist/weather-0.1.0-py3-none-any.whl
 ```
 
-If you are using a virtual environment you can omit the `--user` flag.
+You can still install in editable mode with:
+
+```bash
+pip install -e .
+```
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "weather"
@@ -16,6 +16,9 @@ dependencies = [
 
 [project.scripts]
 weather = "weather.cli:main"
+
+[tool.hatch.version]
+path = "weather/__init__.py"
 
 [tool.black]
 line-length = 88

--- a/weather/__init__.py
+++ b/weather/__init__.py
@@ -4,4 +4,6 @@ from __future__ import annotations
 
 from .core import WeatherError
 
+__version__ = "0.1.0"
+
 __all__ = ["WeatherError"]


### PR DESCRIPTION
## Summary
- switch build backend to hatchling
- document hatch usage in README
- add `__version__` for hatch

## Testing
- `black --check .`

------
https://chatgpt.com/codex/tasks/task_e_688c6a3ce9208325b3a2c426d2ac7a92